### PR TITLE
Add variable note lengths

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -17,6 +17,10 @@
     <script src='https://surikov.github.io/webaudiofontdata/sound/0130_FluidR3_GM_sf2_file.js'></script>
     <!-- marimba -->
     <script src='https://surikov.github.io/webaudiofontdata/sound/0120_FluidR3_GM_sf2_file.js'></script>
+    <!-- piano -->
+    <script src='https://surikov.github.io/webaudiofontdata/sound/0001_FluidR3_GM_sf2_file.js'></script>
+    <!-- acoustic guitar -->
+    <script src='https://surikov.github.io/webaudiofontdata/sound/0240_FluidR3_GM_sf2_file.js'></script>
     <script src="http://reverbjs.org/reverb.js"></script>
 </head>
 <body>

--- a/client/src/Models.elm
+++ b/client/src/Models.elm
@@ -13,6 +13,7 @@ type alias Model =
     , sessionLists : SessionLists
     , route : Route
     , input : String
+    , selectedCell : Cell
     , windowSize : Size
     , serverMessage : String
     , validationErrors : List ValidationError
@@ -75,6 +76,11 @@ type alias TrackId =
     Int
 
 
+type UpdateCellAction
+    = Add
+    | Remove
+
+
 type alias Track =
     { trackId : TrackId
     , clientId : ClientId
@@ -89,6 +95,7 @@ type alias Cell =
     { sessionId : SessionId
     , trackId : TrackId
     , column : Int
+    , length : Int
     , row : Int
     , action : Int
     }
@@ -145,6 +152,7 @@ initialModel route =
         }
     , route = route
     , input = ""
+    , selectedCell = emptyCell
     , windowSize = { width = 0, height = 0 }
     , serverMessage = ""
     , validationErrors = []
@@ -162,15 +170,26 @@ emptySession id =
         [ Track 0
             ""
             ""
-            "Xylophone"
+            "Guitar"
             (List.repeat 13 (List.repeat 8 0))
             [ "C", "B", "A♯", "A", "G♯", "G", "F♯", "F", "E", "D♯", "D", "C♯", "C" ]
         , Track 1
             ""
             ""
-            "Marimba"
+            "Piano"
             (List.repeat 13 (List.repeat 8 0))
             [ "C", "B", "A♯", "A", "G♯", "G", "F♯", "F", "E", "D♯", "D", "C♯", "C" ]
         ]
         []
         []
+
+
+emptyCell : Cell
+emptyCell =
+    { sessionId = 0
+    , trackId = 0
+    , row = 0
+    , column = 0
+    , length = 0
+    , action = 0
+    }

--- a/client/src/Msgs.elm
+++ b/client/src/Msgs.elm
@@ -14,9 +14,10 @@ type Msg
     | OnLocationChange Location
     | ReleaseTrack SessionId TrackId ClientId
     | RequestTrack SessionId TrackId ClientId
+    | SelectCell Cell
     | SelectName
     | Send SessionId
     | ToggleSessionButton SessionId
-    | UpdateBoard Cell
+    | UpdateGrid Cell
     | UserInput String
     | WindowResize Size

--- a/client/src/Styles.elm
+++ b/client/src/Styles.elm
@@ -12,7 +12,9 @@ type Styles
     = ActiveButton
     | Button
     | ErrorMessage
+    | ExtendHandle
     | GridBlock
+    | GridBlockHeld
     | InstrumentLabel
     | Logo
     | Main
@@ -79,8 +81,12 @@ stylesheet =
             [ Font.size 18
             , Color.text (Color.rgb 215 88 19)
             ]
-        , style GridBlock
-            [ Color.background (Color.rgb 120 120 120) ]
+        , style ExtendHandle [ cursor "e-resize" ]
+        , style GridBlock [ Color.background (Color.rgb 120 120 120) ]
+        , style GridBlockHeld
+            [ Color.background (Color.rgb 120 120 120)
+            , cursor "pointer"
+            ]
         , style InstrumentLabel [ Font.size 20 ]
         , style Logo
             [ Font.typeface serif

--- a/client/src/Views.elm
+++ b/client/src/Views.elm
@@ -147,9 +147,8 @@ page model =
                         , column None
                             []
                             (viewBoard
-                                model.sessionId
                                 session.board
-                                model.clientId
+                                ( model.clientId, model.sessionId )
                                 session.beats
                                 session.tones
                                 model.sessionLists.selectedSessions
@@ -210,65 +209,6 @@ page model =
 
         NotFoundRoute ->
             [ textLayout None [] [ text "Not found" ] ]
-
-
-instructions : List (Element Styles variation Msg)
-instructions =
-    [ h3 SubHeading [ paddingTop 10, paddingBottom 20 ] (text "HOW TO USE")
-    , paragraph Text
-        [ paddingBottom 10 ]
-        [ text
-            ("Music in Lunar Rocks is made in sessions. Each sesion has two tracks,"
-                ++ " and you can claim one by selecting "
-            )
-        , bold "Request Track"
-        , text
-            (". Once you have a track, start making music by adding and removing "
-                ++ "notes in the note grid. When you are happy with your creation, select "
-            )
-        , bold "Send "
-        , text "and your music will be sent to the session."
-        ]
-    , paragraph Text
-        [ paddingBottom 10 ]
-        [ text "When you are done with a track, select "
-        , bold "Release Track"
-        , text " to free it. Your music will stay, and someone else can jump in and add their ideas."
-        ]
-    , paragraph Text
-        [ paddingBottom 10 ]
-        [ text
-            ("If someone else is working on a track in your session, you will see and hear "
-                ++ "the changes the changes they make. Collaborate with them! Make beautiful music!"
-            )
-        ]
-    , paragraph Text
-        [ paddingBottom 10 ]
-        [ text
-            ("You can send your track to another session by claiming the same track in both "
-                ++ "sessions, selectng the target session from "
-            )
-        , bold "Your Sessions"
-        , text ", and then selecting "
-        , bold "Broadcast"
-        , text
-            (". You can send to many sessions at once by selecting multiple "
-                ++ "sessions before selecting "
-            )
-        , bold "Broadcast."
-        ]
-    , paragraph Text
-        [ paddingBottom 10 ]
-        [ text "Select "
-        , bold "Leave Session"
-        , text " when you are ready to move on. "
-        , bold "Sessions"
-        , text
-            (" will bring you back to the list of sessions, but "
-                ++ "you will stay active in the current session if you have a track open."
-            )
-        ]
-    ]
 
 
 viewSessionEntry : SessionId -> List SessionId -> Element Styles variation Msg
@@ -339,62 +279,69 @@ viewLabelCell label =
         }
 
 
-viewBoard : SessionId -> Board -> ClientId -> Int -> Int -> List SessionId -> List (Element Styles variation Msg)
-viewBoard sessionId board clientId beats tones selectedSessions =
-    List.concatMap (\t -> viewTrack sessionId t clientId beats tones selectedSessions) board
+viewBoard : Board -> ( ClientId, SessionId ) -> Int -> Int -> List SessionId -> List (Element Styles variation Msg)
+viewBoard board ( clientId, sessionId ) beats tones selectedSessions =
+    List.concatMap (\t -> viewTrack t ( clientId, sessionId ) ( beats, tones ) selectedSessions) board
 
 
-viewTrack : SessionId -> Track -> ClientId -> Int -> Int -> List SessionId -> List (Element Styles variation Msg)
-viewTrack sessionId track clientId beats tones selectedSessions =
-    [ grid GridBlock
-        [ spacing 1 ]
-        { columns = List.repeat beats (px 99)
-        , rows = List.repeat tones (px 13)
-        , cells =
-            viewGrid sessionId track clientId
-        }
-    , paragraph None
-        [ paddingTop 8, paddingBottom 30, spacing 5 ]
-        (case track.username of
-            "" ->
-                [ el InstrumentLabel [] (text track.instrument)
-                , button Button
-                    [ paddingXY 10 2, alignRight, onClick (RequestTrack sessionId track.trackId clientId) ]
-                    (text "Request Track")
-                ]
+viewTrack : Track -> ( ClientId, SessionId ) -> ( Int, Int ) -> List SessionId -> List (Element Styles variation Msg)
+viewTrack track ( clientId, sessionId ) ( beats, tones ) selectedSessions =
+    let
+        style =
+            if track.clientId == clientId then
+                GridBlockHeld
+            else
+                GridBlock
+    in
+        [ grid style
+            [ spacing 1 ]
+            { columns = List.repeat beats (px 99)
+            , rows = List.repeat tones (px 13)
+            , cells =
+                viewGrid track ( clientId, sessionId )
+            }
+        , paragraph None
+            [ paddingTop 8, paddingBottom 30, spacing 5 ]
+            (case track.username of
+                "" ->
+                    [ el InstrumentLabel [] (text track.instrument)
+                    , button Button
+                        [ paddingXY 10 2, alignRight, onClick (RequestTrack sessionId track.trackId clientId) ]
+                        (text "Request Track")
+                    ]
 
-            _ ->
-                [ paragraph InstrumentLabel [ paddingBottom 13 ] [ (text (track.username ++ " on " ++ track.instrument)) ]
-                , when
-                    (clientId == track.clientId)
-                    (button Button
-                        [ paddingXY 10 2, alignRight, onClick (ReleaseTrack sessionId track.trackId "") ]
-                        (text "Release Track")
-                    )
-                , when
-                    (clientId == track.clientId)
-                    (button Button
-                        [ paddingXY 10 2, alignRight, onClick (Send sessionId) ]
-                        (text "Send")
-                    )
-                , when
-                    (((List.length selectedSessions == 1 && Maybe.withDefault 0 (List.head selectedSessions) /= sessionId)
-                        || ((List.length selectedSessions) > 1)
-                     )
-                        && (clientId == track.clientId)
-                    )
-                    (button
-                        Button
-                        [ paddingXY 10 2, alignRight, onClick (Broadcast selectedSessions track) ]
-                        (text "Broadcast")
-                    )
-                ]
-        )
-    ]
+                _ ->
+                    [ paragraph InstrumentLabel [ paddingBottom 13 ] [ (text (track.username ++ " on " ++ track.instrument)) ]
+                    , when
+                        (clientId == track.clientId)
+                        (button Button
+                            [ paddingXY 10 2, alignRight, onClick (ReleaseTrack sessionId track.trackId "") ]
+                            (text "Release Track")
+                        )
+                    , when
+                        (clientId == track.clientId)
+                        (button Button
+                            [ paddingXY 10 2, alignRight, onClick (Send sessionId) ]
+                            (text "Send")
+                        )
+                    , when
+                        (((List.length selectedSessions == 1 && Maybe.withDefault 0 (List.head selectedSessions) /= sessionId)
+                            || ((List.length selectedSessions) > 1)
+                         )
+                            && (clientId == track.clientId)
+                        )
+                        (button
+                            Button
+                            [ paddingXY 10 2, alignRight, onClick (Broadcast selectedSessions track) ]
+                            (text "Broadcast")
+                        )
+                    ]
+            )
+        ]
 
 
-viewGrid : SessionId -> Track -> ClientId -> List (OnGrid (Element Styles variation Msg))
-viewGrid sessionId track clientId =
+viewGrid : Track -> ( ClientId, SessionId ) -> List (OnGrid (Element Styles variation Msg))
+viewGrid track ( clientId, sessionId ) =
     let
         rows =
             List.map (List.indexedMap (,)) track.grid
@@ -402,26 +349,51 @@ viewGrid sessionId track clientId =
         tupleGrid =
             List.indexedMap (,) rows
     in
-        List.concatMap (\r -> viewRow sessionId track clientId r) tupleGrid
+        List.concatMap (\row -> viewRow row track ( clientId, sessionId )) tupleGrid
 
 
-viewRow : SessionId -> Track -> ClientId -> ( Int, List ( Int, Int ) ) -> List (OnGrid (Element Styles variation Msg))
-viewRow sessionId track clientId row =
-    List.map (\c -> viewCell sessionId track clientId (Tuple.first row) c) (Tuple.second row)
+viewRow : ( Int, List ( Int, Int ) ) -> Track -> ( ClientId, SessionId ) -> List (OnGrid (Element Styles variation Msg))
+viewRow ( row, cols ) track ids =
+    case cols of
+        c :: d :: cs ->
+            case Tuple.second c of
+                0 ->
+                    viewCell ( row, c ) track ids :: viewRow ( row, (d :: cs) ) track ids
+
+                _ ->
+                    if (Tuple.second d > Tuple.second c) then
+                        viewRow ( row, (d :: cs) ) track ids
+                    else
+                        viewCell ( row, c ) track ids :: viewRow ( row, (d :: cs) ) track ids
+
+        c :: cs ->
+            viewCell ( row, c ) track ids :: viewRow ( row, cs ) track ids
+
+        [] ->
+            []
 
 
-viewCell : SessionId -> Track -> ClientId -> Int -> ( Int, Int ) -> OnGrid (Element Styles variation Msg)
-viewCell sessionId track clientId row c =
+viewCell : ( Int, ( Int, Int ) ) -> Track -> ( ClientId, SessionId ) -> OnGrid (Element Styles variation Msg)
+viewCell ( row, ( col, action ) ) track ( clientId, sessionId ) =
     let
-        col =
-            Tuple.first c
+        colStart =
+            case action of
+                0 ->
+                    col
 
-        action =
-            Tuple.second c
+                _ ->
+                    -- backtrack to note start
+                    ((col - action) + 1)
     in
         cell
-            { start = ( col, row )
-            , width = 1
+            { start = ( colStart, row )
+            , width =
+                case action of
+                    0 ->
+                        1
+
+                    _ ->
+                        action
             , height = 1
             , content =
                 let
@@ -441,18 +413,97 @@ viewCell sessionId track clientId row c =
                     case clientId == track.clientId of
                         True ->
                             el act
-                                [ onClick
-                                    (UpdateBoard
+                                [ onMouseDown <|
+                                    SelectCell
                                         { sessionId = sessionId
                                         , trackId = track.trackId
-                                        , column = col
                                         , row = row
-                                        , action = (action + 1) % 2
+                                        , column = colStart
+                                        , length = (col - colStart + 1)
+                                        , action = action
                                         }
-                                    )
+                                , onMouseUp <|
+                                    UpdateGrid
+                                        { sessionId = sessionId
+                                        , trackId = track.trackId
+                                        , row = row
+                                        , column = colStart
+                                        , length = (col - colStart + 1)
+                                        , action = action
+                                        }
                                 ]
-                                empty
+                            <|
+                                case action of
+                                    0 ->
+                                        empty
+
+                                    _ ->
+                                        if colStart + action == 8 then
+                                            empty
+                                        else
+                                            el ExtendHandle
+                                                [ alignRight, minHeight (px 13), minWidth (px 10) ]
+                                                empty
 
                         False ->
                             el act [] empty
             }
+
+
+instructions : List (Element Styles variation Msg)
+instructions =
+    [ h3 SubHeading [ paddingTop 10, paddingBottom 20 ] (text "HOW TO USE")
+    , paragraph Text
+        [ paddingBottom 10 ]
+        [ text
+            ("Music in Lunar Rocks is made in sessions. Each sesion has two tracks,"
+                ++ " and you can claim one by selecting "
+            )
+        , bold "Request Track"
+        , text
+            (". Once you have a track, start making music by adding and removing "
+                ++ "notes in the note grid. When you are happy with your creation, select "
+            )
+        , bold "Send "
+        , text "and your music will be sent to the session."
+        ]
+    , paragraph Text
+        [ paddingBottom 10 ]
+        [ text "When you are done with a track, select "
+        , bold "Release Track"
+        , text " to free it. Your music will stay, and someone else can jump in and add their ideas."
+        ]
+    , paragraph Text
+        [ paddingBottom 10 ]
+        [ text
+            ("If someone else is working on a track in your session, you will see and hear "
+                ++ "the changes the changes they make. Collaborate with them! Make beautiful music!"
+            )
+        ]
+    , paragraph Text
+        [ paddingBottom 10 ]
+        [ text
+            ("You can send your track to another session by claiming the same track in both "
+                ++ "sessions, selectng the target session from "
+            )
+        , bold "Your Sessions"
+        , text ", and then selecting "
+        , bold "Broadcast"
+        , text
+            (". You can send to many sessions at once by selecting multiple "
+                ++ "sessions before selecting "
+            )
+        , bold "Broadcast."
+        ]
+    , paragraph Text
+        [ paddingBottom 10 ]
+        [ text "Select "
+        , bold "Leave Session"
+        , text " when you are ready to move on. "
+        , bold "Sessions"
+        , text
+            (" will bring you back to the list of sessions, but "
+                ++ "you will stay active in the current session if you have a track open."
+            )
+        ]
+    ]

--- a/client/src/audio.js
+++ b/client/src/audio.js
@@ -14,20 +14,22 @@ var reverb = audioContext.createReverbFromUrl(reverbUrl, function() {
 var player = new WebAudioFontPlayer();
 /* xylophone */
 player.loader.decodeAfterLoading(audioContext, '_tone_0130_FluidR3_GM_sf2_file');
-/* marimba*/
+/* marimba */
 player.loader.decodeAfterLoading(audioContext, '_tone_0120_FluidR3_GM_sf2_file');
+/* acoustic guitar */
+player.loader.decodeAfterLoading(audioContext, '_tone_0240_FluidR3_GM_sf2_file');
+/* piano */
+player.loader.decodeAfterLoading(audioContext, '_tone_0001_FluidR3_GM_sf2_file');
 
 export function playNote(trackId, tone, duration){
-  if (duration > 0) {
     if (trackId === 0) {
       player.queueWaveTable(audioContext, lowpassFilter
-                            , _tone_0130_FluidR3_GM_sf2_file , 0, (12*6+tone), 1, 0.5);
+                            , _tone_0240_FluidR3_GM_sf2_file , 0, (12*6+tone), duration*0.5, 0.5);
     }
     else {
       player.queueWaveTable(audioContext, lowpassFilter
-                            , _tone_0120_FluidR3_GM_sf2_file , 0, (12*4+tone), 1, 0.3);
+                            , _tone_0001_FluidR3_GM_sf2_file , 0, (12*4+tone), duration*0.5, 0.3);
     }
-  }
   return false;
 }
 

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -21,7 +21,7 @@ var score = [];
 
 // process score
 app.ports.sendScore.subscribe(function (args) {
-    if (args.length > 1) {
+    if (args.length > 0) {
         play = true;
         var newScore = [];
         for (var i = 1; i <= beats; i++) {
@@ -43,7 +43,7 @@ app.ports.sendScore.subscribe(function (args) {
 
 // loop over eight beats, schedule one second ahead for each
 var loop = clock.callbackAtTime(function() {
-  console.log(beat);
+  // console.log(beat);
   // play notes for current beat
   if (play) {
     var notes = score[beat];


### PR DESCRIPTION
Only reads in notes to score, not rests.
Instruments hard-coded to guitar and piano for now. Instrument selection coming
next.
Note selection is imperfect. If multiple notes are dragged over they get focus,
and the selection is not visible. This could be fixed by forcing blur or by
showing the selection and adding the ability to move notes.