### PR TITLE
Accounts service standup

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -92,7 +92,36 @@ Navigate to `localhost:1025/` in your favorite browser
 
 ### Accounts
 
-TODO
+__Local Development: Install Postgres:__
+
+Create a file in `lunar-rocks/go/` directory called `psql_creds.rc`. This file
+should contain two lines:
+
+```
+PSQLUSER=xxx
+PSQLPW=yyy
+```
+
+Where `xxx` is your desired local-dev username, and `yyy` is your desired local
+dev password.
+
+Next, run the `postgres_setup.sh` script, which will prompt you for your sudo
+password and install the required apt packages.
+
+This script should also import your devel credentials and set up a postgresql user
+with them, as well as create an Accounts schema in the default database and
+give your user permissions to create and alter tables in that schema.
+
+__Note:__
+
+You may want to also create a `.pgpass` file in your home directory with the
+following line:
+
+`localhost:*:postgres:psqluser:psqlpw`
+
+This will enable you to log into an interactive postgres prompt with your devel
+credentials for debugging or testing, though this can be avoided using the
+`-W` switch when running `psql` to force a password prompt.
 
 ==================================================
 

--- a/go/README.md
+++ b/go/README.md
@@ -4,8 +4,6 @@ The Lunar Rocks backend is comprised of several independent services. See the
 individual per-service sections in this document for brief discussions of
 those, and find more detailed READMEs in the subdirectory for each service.
 
-==================================================
-
 ## Direnv
 
 Direnv acts like a virtualenv for go development, and will help keep your local
@@ -45,13 +43,10 @@ to access your filesystem by running:
 
 This should conclude the setup process for direnv.
 
-==================================================
-
 ## Services
 
----
-
 ### Webserver
+---
 
 __Basic Compilation and Runtime__
 
@@ -85,12 +80,12 @@ to learn a bit more):
 `-port=#`: set the port for the server to listen on
 
 __Finally__
+`sudo ./bin/webserver`
 
 Navigate to `localhost:1025/` in your favorite browser
 
----
-
 ### Accounts
+---
 
 __Local Development: Install Postgres:__
 
@@ -105,8 +100,12 @@ PSQLPW=yyy
 Where `xxx` is your desired local-dev username, and `yyy` is your desired local
 dev password.
 
-Next, run the `postgres_setup.sh` script, which will prompt you for your sudo
-password and install the required apt packages.
+Next, run the postgres setup script with 
+
+`./postgres_setup.sh`
+
+which will prompt you for your sudo password and install the required apt
+packages.
 
 This script should also import your devel credentials and set up a postgresql user
 with them, as well as create an Accounts schema in the default database and
@@ -123,8 +122,6 @@ This will enable you to log into an interactive postgres prompt with your devel
 credentials for debugging or testing, though this can be avoided using the
 `-W` switch when running `psql` to force a password prompt.
 
-==================================================
-
-TODO
+## TODO
 
 compile & run script?

--- a/go/README.md
+++ b/go/README.md
@@ -116,7 +116,11 @@ __Note:__
 You may want to also create a `.pgpass` file in your home directory with the
 following line:
 
-`localhost:*:postgres:psqluser:psqlpw`
+`host:port:dbname:psqluser:psqlpw`
+
+e.g.
+
+`localhost:5433:accounts:guy:mypw`
 
 This will enable you to log into an interactive postgres prompt with your devel
 credentials for debugging or testing, though this can be avoided using the

--- a/go/postgres_setup.sh
+++ b/go/postgres_setup.sh
@@ -27,13 +27,21 @@ else
     echo "postgres-contrib is already installed. Not installing..."
 fi
 
+sudo -u postgres psql -U postgres -c "CREATE DATABASE accounts;" || true
 # configure Postgres schema and local dev account permissions
-sudo -u postgres psql -U postgres -c "CREATE SCHEMA Accounts;" || true
+sudo -u postgres psql -U postgres -d accounts -c "CREATE SCHEMA registered_accounts;" || true
 set +x
-sudo -u postgres psql -U postgres -c "CREATE USER ${PSQLUSER} with PASSWORD '${PSQLPW}';"
+sudo -u postgres psql -U postgres -d accounts -c "CREATE USER ${PSQLUSER} with PASSWORD '${PSQLPW}';" || true
 set -x
-echo "Created user account ${PSQLUSER} for Account schema"
-sudo -u postgres psql -U postgres -c "GRANT ALL ON SCHEMA Accounts TO ${PSQLUSER};"
-sudo -u postgres psql -U postgres -c "GRANT ALL ON ALL TABLES IN SCHEMA Accounts TO ${PSQLUSER};"
+echo "Created user account ${PSQLUSER} for registered_accounts schema"
+sudo -u postgres psql -U postgres -d accounts -c "CREATE TABLE registered_accounts.registered 
+(id varchar(255) PRIMARY KEY,
+username varchar(255) UNIQUE NOT NULL,
+email varchar(255) NOT NULL,
+passHash bytea NOT NULL
+);" || true
+sudo -u postgres psql -U postgres -d accounts -c "GRANT ALL ON DATABASE accounts TO ${PSQLUSER};"
+sudo -u postgres psql -U postgres -d accounts -c "GRANT ALL ON SCHEMA registered_accounts TO ${PSQLUSER};"
+sudo -u postgres psql -U postgres -d accounts -c "GRANT ALL ON ALL TABLES IN SCHEMA registered_accounts TO ${PSQLUSER};"
 
 echo "postgres setup complete!"

--- a/go/postgres_setup.sh
+++ b/go/postgres_setup.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# -e: Exit immediately if command exits with nonzero status
+# -u: Treat unset variables as an error when substituting
+# -x: Print commands and their arguments as they are executed
+set -eux
+
+echo "Starting postgres setup script..."
+
+# Load psql_creds.rc file
+CREDSFILE="psql_creds.rc"
+set +x # hide credentials from output
+source "${PWD}/${CREDSFILE}"
+set -x
+
+# Install postgres if it is not already present
+if [ `dpkg-query -l | grep -q postgresql` ]; then
+    echo "postgres not found. Installing..."
+    sudo apt-get install --assume-yes postgresql
+else
+    echo "postgres is already installed. Not installing..."
+fi
+if [ `dpkg-query -l | grep -q postgresql-contrib` ]; then
+    echo "postgres-contrib not found. Installing..."
+    sudo apt-get install --assume-yes postgresql-contrib
+else
+    echo "postgres-contrib is already installed. Not installing..."
+fi
+
+# configure Postgres schema and local dev account permissions
+sudo -u postgres psql -U postgres -c "CREATE SCHEMA Accounts;" || true
+set +x
+sudo -u postgres psql -U postgres -c "CREATE USER ${PSQLUSER} with PASSWORD '${PSQLPW}';"
+set -x
+echo "Created user account ${PSQLUSER} for Account schema"
+sudo -u postgres psql -U postgres -c "GRANT ALL ON SCHEMA Accounts TO ${PSQLUSER};"
+sudo -u postgres psql -U postgres -c "GRANT ALL ON ALL TABLES IN SCHEMA Accounts TO ${PSQLUSER};"
+
+echo "postgres setup complete!"

--- a/go/src/accounts/account.go
+++ b/go/src/accounts/account.go
@@ -1,8 +1,11 @@
 package main
 
 type Account struct {
-	ID       string
-	Username string
-	Hash     []byte
-	Email    string
+	User PostAccount `json:"user"`
+}
+
+type PostAccount struct {
+	Email    string `json:"email"`
+	Username string `json:"username"`
+	Password string `json:"password"`
 }

--- a/go/src/accounts/account.go
+++ b/go/src/accounts/account.go
@@ -1,0 +1,8 @@
+package main
+
+type Account struct {
+	ID       string
+	Username string
+	Hash     []byte
+	Email    string
+}

--- a/go/src/accounts/main.go
+++ b/go/src/accounts/main.go
@@ -24,7 +24,7 @@ func main() {
 	var logLevel string
 	flag.StringVar(&credsFile, "creds", "psql_creds.rc",
 		"File to find Postgres credentials")
-	flag.StringVar(&listenPort, "port", "1025",
+	flag.StringVar(&listenPort, "port", "9000",
 		"port for server to listen on")
 	flag.StringVar(&logLevel, "log", "v",
 		"Log Levels\nn: Errors only\nq: Info\nv: Debug\nvvv: Trace")
@@ -51,7 +51,8 @@ func main() {
 	r := mux.NewRouter()
 
 	// Handle calls to index and elm.js with same function
-	r.HandleFunc("/register", registerHandle).Methods("POST")
+	// r.HandleFunc("/register", registerHandle).Methods("POST")
+	r.HandleFunc("/register", registerHandle)
 
 	// Serve and log
 	err := http.ListenAndServe(":"+listenPort, r)
@@ -63,6 +64,12 @@ func check(e error) {
 	if e != nil {
 		log.Fatal(e)
 	}
+}
+
+func enableCors(w *http.ResponseWriter, req *http.Request) {
+	(*w).Header().Set("Access-Control-Allow-Origin", "*")
+	(*w).Header().Set("Access-Control-Allow-Methods", "POST")
+	(*w).Header().Set("Access-Control-Allow-Headers", "Content-Type, Content-Length")
 }
 
 func dbInit(credsFile string) *sql.DB {
@@ -93,6 +100,16 @@ func dbInit(credsFile string) *sql.DB {
 }
 
 func registerHandle(w http.ResponseWriter, r *http.Request) {
+	log.Info("registerHandle called")
+	log.Info(r.Method)
+
+	enableCors(&w, r)
+	if r.Method == "OPTIONS" {
+		return
+	}
+
+	err := r.ParseForm()
+	check(err)
 	user := r.FormValue("user")
 	email := r.FormValue("email")
 	pw := r.FormValue("password")

--- a/go/src/accounts/main.go
+++ b/go/src/accounts/main.go
@@ -1,31 +1,101 @@
 package main
 
 import (
-	"encoding/json"
-	"github.com/gorilla/mux"
-	log "github.com/sirupsen/logrus"
+	"database/sql"
+	"flag"
+	"fmt"
+	"io/ioutil"
 	"net/http"
+	"regexp"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/gorilla/mux"
+	_ "github.com/lib/pq"
 )
 
+var db *sql.DB
+
 func main() {
-	router := mux.NewRouter()
-	r.Schemes("https")
 
-	// Routes
-	r.HandleFunc("/accounts", GetAccounts).Methods("GET")
-	r.HandleFunc("/accounts/{id}", GetAccount).Methods("GET")
-	r.HandleFunc("/accounts/{id}", CreateAccount).Methods("POST")
-	r.HandleFunc("/accounts/{id}", DeleteAccount).Methods("DELETE")
+	// get any cli options
+	var credsFile string
+	var listenPort string
+	var logLevel string
+	flag.StringVar(&credsFile, "creds", "psql_creds.rc",
+		"File to find Postgres credentials")
+	flag.StringVar(&listenPort, "port", "1025",
+		"port for server to listen on")
+	flag.StringVar(&logLevel, "log", "v",
+		"Log Levels\nn: Errors only\nq: Info\nv: Debug\nvvv: Trace")
+	flag.Parse()
 
-	// serve HTTPS on port 443
-	err := http.ListenAndServeTLS(":443", "server.crt", "server.key", r)
+	// set log level
+	var ll log.Level
+	switch logLevel {
+	case "n":
+		ll = log.ErrorLevel
+	case "q":
+		ll = log.InfoLevel
+	case "v":
+		ll = log.DebugLevel
+	case "vvv":
+		ll = log.TraceLevel
+	}
+	log.SetLevel(ll)
+	db = dbInit(credsFile)
+	log.Info("Webserver start")
+	log.Info("Lisening on port: " + listenPort)
 
-	if err != nil {
-		log.Fatal("ListenandServeTLS: ", err)
+	// instantiate the web router
+	r := mux.NewRouter()
+
+	// Handle calls to index and elm.js with same function
+	r.HandleFunc("/register", registerHandle).Methods("POST")
+
+	// Serve and log
+	err := http.ListenAndServe(":"+listenPort, r)
+
+	check(err)
+}
+
+func check(e error) {
+	if e != nil {
+		log.Fatal(e)
 	}
 }
 
-func GetAccounts(w http.ResponseWriter, r *http.Request)   {}
-func GetAccount(w http.ResponseWriter, r *http.Request)    {}
-func CreateAccount(w http.ResponseWriter, r *http.Request) {}
-func DeleteAccount(w http.ResponseWriter, r *http.Request) {}
+func dbInit(credsFile string) *sql.DB {
+	// open the creds file and read contents
+	prefix := "PSQLUSER=.*"
+	f, err := ioutil.ReadFile(credsFile)
+	check(err)
+	fileStr := string(f)
+	// use regex to find the username
+	re := regexp.MustCompile(prefix)
+	str := re.FindString(fileStr)
+	fmt.Println(str)
+	user := str[len(prefix):]
+	// connect to postgres
+	connStr := fmt.Sprintf("user=%s dbname=accounts sslmode=verify-full", user)
+	db, err := sql.Open("postgres", connStr)
+	check(err)
+	tables, err := db.Query("show tables")
+	if tables == nil {
+		db.Query(`create table registered (
+			username varchar(255),
+			email varchar(255),
+			passHash varchar(255)
+		)`)
+	}
+	log.Info("Connect to postgres successful")
+	return db
+}
+
+func registerHandle(w http.ResponseWriter, r *http.Request) {
+	user := r.FormValue("user")
+	email := r.FormValue("email")
+	pw := r.FormValue("password")
+	log.Info(user, email, pw)
+	db.Query(fmt.Sprintf("insert into registered (%s, %s, %s)", user, email, pw))
+}

--- a/go/src/accounts/main.go
+++ b/go/src/accounts/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+)
+
+func main() {
+	router := mux.NewRouter()
+	r.Schemes("https")
+
+	// Routes
+	r.HandleFunc("/accounts", GetAccounts).Methods("GET")
+	r.HandleFunc("/accounts/{id}", GetAccount).Methods("GET")
+	r.HandleFunc("/accounts/{id}", CreateAccount).Methods("POST")
+	r.HandleFunc("/accounts/{id}", DeleteAccount).Methods("DELETE")
+
+	// serve HTTPS on port 443
+	err := http.ListenAndServeTLS(":443", "server.crt", "server.key", r)
+
+	if err != nil {
+		log.Fatal("ListenandServeTLS: ", err)
+	}
+}
+
+func GetAccounts(w http.ResponseWriter, r *http.Request)   {}
+func GetAccount(w http.ResponseWriter, r *http.Request)    {}
+func CreateAccount(w http.ResponseWriter, r *http.Request) {}
+func DeleteAccount(w http.ResponseWriter, r *http.Request) {}


### PR DESCRIPTION
With this commit, the accounts service can accept registrations, via the `/register` endpoint, and add them to the database. I've tested this in a functional way, but obvs there are no integrated tests as of yet.

This currently hashes the password with bcrypt before storing the bits in the DB. I've got a couple of TODOs still, like checking for unique usernames (though that may be handled by the DB constraints), exception handling, and using uuids for account primary keys.

Let me know if you have opinions about the naming scheme, which organizes the "registered" table under the "registered_accounts" schema, which lives in the "accounts" database. 

Also let me know if the readme is clear enough. I've supplied a DB setup script to do all the lifting there, but if you can think of a better way to do this, let me know.